### PR TITLE
use absolute path to load autoloader

### DIFF
--- a/tpay.php
+++ b/tpay.php
@@ -126,7 +126,7 @@ function init_gateway_tpay()
     }
 
     load_plugin_textdomain('tpay', false, dirname(plugin_basename(__FILE__)).'/lang/');
-    require_once 'vendor/autoload.php';
+    require_once realpath( __DIR__ . '/vendor/autoload.php' );
     Logger::setLogger(new TpayLogger());
 
     add_filter('woocommerce_payment_gateways', 'add_tpay_gateways');


### PR DESCRIPTION
Always use absolute path when including autoloader. 

This will fix composer autoloading issue when using wp-cli (see similar issue here https://github.com/wp-cli/wp-cli/issues/4632).